### PR TITLE
Expand testing infrastructure and separate example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ language: julia
 os:
   - linux
 julia:
-  - release
+  - 0.4
+  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,17 @@
 environment:
   matrix:
-  - JULIAVERSION: "julialang/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIAVERSION: "julialang/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIAVERSION: "julianightlies/bin/winnt/x64/julia-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
+  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 
 branches:
   only:
     - master
-    - /release-.*/
 
 notifications:
   - provider: Email
@@ -17,9 +20,15 @@ notifications:
     on_build_status_changed: false
 
 install:
+  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
+# If there's a newer build queued for the same PR, cancel this one
+  - ps: if ($env:APPVEYOR_PULL_REQUEST_NUMBER -and $env:APPVEYOR_BUILD_NUMBER -ne ((Invoke-RestMethod `
+        https://ci.appveyor.com/api/projects/$env:APPVEYOR_ACCOUNT_NAME/$env:APPVEYOR_PROJECT_SLUG/history?recordsNumber=50).builds | `
+        Where-Object pullRequestId -eq $env:APPVEYOR_PULL_REQUEST_NUMBER)[0].buildNumber) { `
+        throw "There are newer queued builds for this pull request, failing early." }
 # Download most recent Julia Windows binary
   - ps: (new-object net.webclient).DownloadFile(
-        $("http://s3.amazonaws.com/"+$env:JULIAVERSION),
+        $env:JULIA_URL,
         "C:\projects\julia-binary.exe")
 # Run installer silently, output to C:\projects\julia
   - C:\projects\julia-binary.exe /S /D=C:\projects\julia

--- a/examples/random.jl
+++ b/examples/random.jl
@@ -1,0 +1,28 @@
+# Random Dictionary based example
+using PyPlot
+
+dim     = 64
+n_elems = 1024;
+D       = randn(dim,n_elems);
+s       = randn(dim)
+sparse  = lca(s , D, T_soft=0.4)
+
+println("Original  Sparsity = ", sum(s.!=0))
+println("Original  RMS      = ", sqrt(mean(s.^2)))
+println("Resulting Sparsity = ", sum(sparse.!=0))
+println("Recovery  RMS      = ", sqrt(mean((s.-D*sparse).^2)))
+
+
+figure(1)
+PyPlot.clf()
+title("Sparse Realization of input")
+xlabel("Dictionary Element")
+ylabel("Magnitude")
+stem(sparse)
+
+figure(2)
+PyPlot.clf()
+title("Reconstruction of random input")
+plot(s)
+plot(D*sparse)
+legend(["Original", "Recovered"])

--- a/src/LCA.jl
+++ b/src/LCA.jl
@@ -64,35 +64,4 @@ function lca(s::Vector{Float64}, D::Matrix{Float64}; T_soft::Float64=0.1,
     return a
 end
 
-if(false)
-    # Random Dictionary based example
-    using PyPlot
-
-    dim     = 64
-    n_elems = 1024;
-    D       = randn(dim,n_elems);
-    s       = randn(dim)
-    sparse  = lca(s , D, T_soft=0.4)
-
-    println("Original  Sparsity = ", sum(s.!=0))
-    println("Original  RMS      = ", sqrt(mean(s.^2)))
-    println("Resulting Sparsity = ", sum(sparse.!=0))
-    println("Recovery  RMS      = ", sqrt(mean((s.-D*sparse).^2)))
-
-
-    figure(1)
-    PyPlot.clf()
-    title("Sparse Realization of input")
-    xlabel("Dictionary Element")
-    ylabel("Magnitude")
-    stem(sparse)
-
-    figure(2)
-    PyPlot.clf()
-    title("Reconstruction of random input")
-    plot(s)
-    plot(D*sparse)
-    legend(["Original", "Recovered"])
-end
-
 end # module


### PR DESCRIPTION
Ref https://github.com/JuliaLang/METADATA.jl/pull/10764

The package has its minimum Julia version at 0.4 but Travis was only set up to test on 0.6 and 0.7. This PR sets up Travis and AppVeyor to test on 0.4-0.7 and separates the plotting example out into a separate file. This was done so that the package could still have the PyPlot code but it wouldn't be a requirement to install the package.

The CI stuff doesn't need to change before the package is registered, but the plotting code should be moved.